### PR TITLE
Fix for MFANumber

### DIFF
--- a/audit-mailboxes.ps1
+++ b/audit-mailboxes.ps1
@@ -2,7 +2,7 @@ try {Get-MsolDomain -ErrorAction stop} catch {Write-Error -Category Authenticati
 try {Get-Mailbox -resultsize 1 -ErrorAction stop} catch {Write-Error -Category AuthenticationError  -Message "Exchange Online Not Connected" -RecommendedAction "Check readme file for instructions" -TargetObject "Office365 Exchange"  -CategoryTargetName "NotConnected" -CategoryTargetType "Online Services";exit} # Determine if Exchange sessions is connected
 
 $mailboxes = get-mailbox -resultsize unlimited -Filter {RecipientTypeDetails -ne "DiscoveryMailbox"} #Get all mailboxes except discovery mailboxes
-$mailboxes|Add-Member -MemberType NoteProperty -Name "MFAEnabled" -value "" # Add extra properties to mailbox object
+$mailboxes|Add-Member -MemberType NoteProperty -Name "MFANumber" -value "" # Add extra properties to mailbox object
 $mailboxes|Add-Member -MemberType NoteProperty -Name "DelegatedAccess" -value ""
 $mailboxes|Add-Member -MemberType NoteProperty -Name "Office365Administrator" -value ""
 $admins = Get-MsolRoleMember -RoleObjectId (Get-MsolRole -RoleName "Company Administrator").ObjectId
@@ -24,4 +24,4 @@ $mb = $mailboxes| ForEach-Object { # For each mailbox
     }
     return $_
 }
-$mb|select-object UserPrincipalName, MFAEnabled, DelegatedAccess, auditenabled, Office365Administrator|export-excel -IncludePivotTable -PivotRows AuditEnabled -PivotData @{UserPrincipalName = "count"} -IncludePivotChart -ChartType Doughnut -Show -Path ".\out.xlsx"
+$mb|select-object UserPrincipalName, MFANumber, DelegatedAccess, auditenabled, Office365Administrator|export-excel -IncludePivotTable -PivotRows AuditEnabled -PivotData @{UserPrincipalName = "count"} -IncludePivotChart -ChartType Doughnut -Show -Path ".\out.xlsx"


### PR DESCRIPTION
Updating audit-mailboxes.ps1 to add the MFANumber Property and then output said property when the script is complete. The current name, MFAEnabled, isn't used and its use within the try/catch section causes an exception.